### PR TITLE
Ensure Presenter height never grows beyond screen height

### DIFF
--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -348,7 +348,10 @@ namespace org.westhoffswelt.pdfpresenter.Window {
 
             var nextViewWithNotes = new VBox(false, 0);
             nextViewWithNotes.pack_start( this.next_view, false, false, 0 );
-            nextViewWithNotes.pack_start( this.notes_view, true, true, 5 );
+            var notes_sw = new ScrolledWindow(null, null);
+            notes_sw.add( this.notes_view );
+            notes_sw.set_policy( PolicyType.AUTOMATIC, PolicyType.AUTOMATIC );
+            nextViewWithNotes.pack_start( notes_sw, true, true, 5 );
             this.slideViews.add(nextViewWithNotes);
 
             var bottomRow = new HBox(true, 0);


### PR DESCRIPTION
A full-screen window that has a height greater than the screen height experiences all sorts of weird, wonderful breakage, at least in Gnome 3.  I found two ways in which this could happen:
1. The current view + strict view + bottom bar could be taller than the screen.
2. The notes view could extend downwards as text was added.
These commits fix both issues.
