### PR TITLE
Ensure custom_slide_count always uses same total

### DIFF
--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -364,7 +364,7 @@ namespace org.westhoffswelt.pdfpresenter.Window {
             button[this.currently_selected].unset_current();
             button[b].set_current();
             this.currently_selected = b;
-            this.presenter.custom_slide_count(this.currently_selected+1, (int)this.n_slides);
+            this.presenter.custom_slide_count(this.currently_selected + 1);
         }
 
         /**

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -423,12 +423,12 @@ namespace org.westhoffswelt.pdfpresenter.Window {
          */
         protected void update_slide_count() {
             this.custom_slide_count(
-                    this.presentation_controller.get_current_user_slide_number() + 1, 
-                    this.presentation_controller.get_end_user_slide()
+                    this.presentation_controller.get_current_user_slide_number() + 1
             );
         }
 
-        public void custom_slide_count(int current, int total) {
+        public void custom_slide_count(int current) {
+            int total = this.presentation_controller.get_end_user_slide();
             this.slide_progress.set_text( "%d/%u".printf(current, total) );
         }
 


### PR DESCRIPTION
With a custom ending slide, the presenter and overview could give different numbers for the total slides.  This fixes that by figuring the total number of slides directly in custom_slide_count.
