### PR TITLE
Only allow switch to overview mode if it is available

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -633,10 +633,12 @@ namespace org.westhoffswelt.pdfpresenter {
         }
 
         protected void controllables_show_overview() {
-            this.set_ignore_mouse_events(true);
-            this.current_key_mapping = this.KeyMappings.Overview;
-            foreach( Controllable c in this.controllables )
-                c.show_overview();
+            if (this.overview != null) {
+                this.set_ignore_mouse_events(true);
+                this.current_key_mapping = this.KeyMappings.Overview;
+                foreach( Controllable c in this.controllables )
+                    c.show_overview();
+            }
         }
 
         protected void controllables_hide_overview() {


### PR DESCRIPTION
If you launch pdfpc with -sS (using mirrored monitors, for example), there is no presenter window and therefore no overview.  However, pressing Tab will still switch into overview key control mode, with the practical effect that most of they keys apparently do nothing.

This patch only allows the switch if the overview window exists.

More speculatively, maybe pdfpc should display the overview on the presentation window in this case.  (But that would be another issue.)
