### PR TITLE
Ensure that images show up in overview

### DIFF
--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -139,6 +139,10 @@ namespace org.westhoffswelt.pdfpresenter {
             Gdk.threads_init();
             Gtk.init( ref args );
 
+            // Needed to show the images in the overview
+            var default_settings = Gtk.Settings.get_default();
+            default_settings.set("gtk_button_images", true);
+
             // Initialize the application wide mutex objects
             MutexLocks.init();
 


### PR DESCRIPTION
New versions of Gnome turn off images in buttons by default.  We could deal with this by jumping through hoops for each button, but instead we just change the settings.
