### PR TITLE
Pdfpc doesn't compile under Ubuntu 11.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(ValaVersion)
 
 find_package(Vala)
 
-ensure_vala_version("0.16.0" MINIMUM)
+ensure_vala_version("0.11.0" MINIMUM)
 
 add_subdirectory(src)
 add_subdirectory(icons)

--- a/src/classes/view/behaviour/pdf_link/signal_provider.vala
+++ b/src/classes/view/behaviour/pdf_link/signal_provider.vala
@@ -68,8 +68,8 @@ namespace org.westhoffswelt.pdfpresenter.View.Behaviour {
         /**
          * Poppler.LinkMappings of the current page
          */
-        //protected unowned GLib.List<unowned Poppler.LinkMapping> page_link_mappings = null;
-        protected GLib.List<Poppler.LinkMapping> page_link_mappings = null;
+        protected unowned GLib.List<unowned Poppler.LinkMapping> page_link_mappings = null;
+        //protected GLib.List<Poppler.LinkMapping> page_link_mappings = null;
 
         /**
          * Precalculated Gdk.Rectangles for every link mapping
@@ -134,7 +134,7 @@ namespace org.westhoffswelt.pdfpresenter.View.Behaviour {
                             var document = metadata.get_document();
                             //unowned Poppler.Dest destination;
                             //destination = document.find_dest(
-                            Poppler.Dest destination = document.find_dest( 
+                            unowned Poppler.Dest destination = document.find_dest( 
                                 action.dest.named_dest
                             );
                             MutexLocks.poppler.unlock();


### PR DESCRIPTION
These are the changes I had to make to get pdfpc to compile in Ubuntu 11.10.  They revert some recent changes made in the trunk, and obviously they won't be accepted in their current form.  But maybe we can work out some way to make the compilation work with a range of versions.

Some (potentially) relevant versions for 11.10:
- valac 0.14.0
- libpoppler 0.16.7
- libgtk2.0 2.24.6
- libgtk-3 3.2.0

(Sorry for the flurry of pull requests -- please take it as a sign of my excitement about pdfpc.)
