### PR TITLE
SignalProvider: Include locks in vala version test

### DIFF
--- a/src/classes/view/behaviour/pdf_link/signal_provider.vala
+++ b/src/classes/view/behaviour/pdf_link/signal_provider.vala
@@ -312,13 +312,13 @@ namespace org.westhoffswelt.pdfpresenter.View.Behaviour {
             this.precalculated_mapping_rectangles = null;
 
             // Free the mapping memory
-            MutexLocks.poppler.lock();
 #if !VALA_0_16
+            MutexLocks.poppler.lock();
             Poppler.Page.free_link_mapping(  
                 this.page_link_mappings
             );
-#endif
             MutexLocks.poppler.unlock();
+#endif
         }
     }
 }


### PR DESCRIPTION
Looking at the version test code again, I realized that there's no need to get the Poppler lock for Vala > 0.16, since we don't do anything with it.  I doubt that there are actually any performance implications here, but this may help avoid confusion in the future.
