### PR TITLE
Add windowed mode

### DIFF
--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -38,6 +38,11 @@ namespace org.westhoffswelt.pdfpresenter {
         public static bool single_screen = false;
         
         /**
+         * Commandline option to run in windowed mode
+         */
+        public static bool windowed = false;
+        
+        /**
          * Commandline option which allows the complete disabling of slide caching
          */
         public static bool disable_caching = false;

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -68,19 +68,26 @@ namespace org.westhoffswelt.pdfpresenter.Window {
                 int current_screen = screen.get_monitor_at_point(pointerx, pointery);
                 screen.get_monitor_geometry( current_screen, out this.screen_geometry );
             }
-                
-            // Move to the correct monitor
-            // This movement is done here and after mapping, to minimize flickering
-            // with window managers, which correctly handle the movement command,
-            // before the window is mapped.
-            this.move( this.screen_geometry.x, this.screen_geometry.y );
-            //this.fullscreen();
 
-            // As certain window-managers like Xfwm4 ignore movement request
-            // before the window is initially moved and set up we need to
-            // listen to this event.
-            this.size_allocate.connect( this.on_size_allocate );
-            this.configure_event.connect( this.on_configure );
+            if ( !Options.windowed ) {
+                // Move to the correct monitor
+                // This movement is done here and after mapping, to minimize flickering
+                // with window managers, which correctly handle the movement command,
+                // before the window is mapped.
+                this.move( this.screen_geometry.x, this.screen_geometry.y );
+                //this.fullscreen();
+
+                // As certain window-managers like Xfwm4 ignore movement request
+                // before the window is initially moved and set up we need to
+                // listen to this event.
+                this.size_allocate.connect( this.on_size_allocate );
+                this.configure_event.connect( this.on_configure );
+            }
+            else {
+                this.screen_geometry.width /= 2;
+                this.screen_geometry.height /= 2;
+                this.resizable = false;
+            }
 
             this.add_events(EventMask.POINTER_MOTION_MASK);
             this.motion_notify_event.connect( this.on_mouse_move );

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -72,6 +72,7 @@ namespace org.westhoffswelt.pdfpresenter {
             { "disable-compression", 'z', 0, 0, ref Options.disable_cache_compression, "Disable the compression of slide images to trade memory consumption for speed. (Avg. factor 30)", null },
             { "black-on-end", 'b', 0, 0, ref Options.black_on_end, "Add an additional black slide at the end of the presentation", null },
             { "single-screen", 'S', 0, 0, ref Options.single_screen, "Force to use only one screen", null },
+            { "windowed", 'w', 0, 0, ref Options.windowed, "Run in windowed mode", null},
             { null }
         };
 
@@ -170,12 +171,20 @@ namespace org.westhoffswelt.pdfpresenter {
             }
             else {
                 stdout.printf( "Using only one screen\n" );
-                if ( !Options.display_switch)
-                    this.presenter_window = 
+                if ( Options.windowed ) {
+                    this.presenter_window =
                         this.create_presenter_window( metadata, -1 );
-                else
-                    this.presentation_window = 
+                    this.presentation_window =
                         this.create_presentation_window( metadata, -1 );
+                }
+                else {
+                    if ( !Options.display_switch)
+                        this.presenter_window =
+                            this.create_presenter_window( metadata, -1 );
+                    else
+                        this.presentation_window =
+                            this.create_presentation_window( metadata, -1 );
+                }
             }
 
             // The windows are always displayed at last to be sure all caches have


### PR DESCRIPTION
This is a change I made to aid development.  It lets you see both the presenter and presentation windows when you don't have a second monitor.  It makes no attempt to be useful in the general case.  Notably, the windows are not resizable or fullscreenable.

If you don't want this sort of dev tool in the trunk, I completely understand.  I just thought I'd throw it out in case others find it useful.
