### PR TITLE
Load notes from "text"-annotations

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -257,6 +257,25 @@ namespace pdfpc.Metadata {
         }
 
         /**
+         * Fill the slide notes from pdf text annotations.
+         */
+        private void notes_from_document() {
+            for(int i = 0; i < this.page_count; i++) {
+                var page = this.document.get_page(i);
+                unowned List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
+                foreach(unowned Poppler.AnnotMapping am in anns) {
+                    var a = am.annot;
+                    switch(a.get_annot_type()) {
+                        case Poppler.AnnotType.TEXT:
+                            this.notes.set_note(a.get_contents(), real_slide_to_user_slide(i));
+                            break;
+                    }
+                }
+                page.free_annot_mapping(anns);
+            }
+        }
+
+        /**
          * Base constructor taking the file url to the pdf file
          */
         public Pdf( string fname ) {
@@ -294,6 +313,10 @@ namespace pdfpc.Metadata {
             } else {
                 parse_skip_line(skip_line);
             }
+
+            // Prepopulate notes from annotations
+            notes_from_document();
+
             MutexLocks.poppler.unlock();
         }
     


### PR DESCRIPTION
As mentioned in [#25](https://github.com/davvil/pdfpc/issues/25), this pulls PDF text annotations into the notes on load.
(currently overwriting any user-specified notes. I think users who would put such notes into their PDF don't want to edit them in the viewer anyway.)

In a LaTeX beamer document, notes can be generated like this:

``` latex
\usepackage{pdfcomment}
...
\begin{frame}
  content
  \pdfcomment{This won't appear anywhere because it's overwritten by the next note.}
  \pdfcomment{This will appear in the notes section, not on the page.}
\end{frame}


\begin{frame}
  \vspace{-\normalbaselineskip}%
  \pdfcomment[open=true,icon={},color=yellow]{Should be invisible and occupy no space}
\end{frame}
```
