### PR TITLE
Make notes_from_document() work with Vala >= 0.16

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -262,7 +262,11 @@ namespace pdfpc.Metadata {
         private void notes_from_document() {
             for(int i = 0; i < this.page_count; i++) {
                 var page = this.document.get_page(i);
+#if VALA_0_16
+                List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
+#else
                 unowned List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
+#endif
                 foreach(unowned Poppler.AnnotMapping am in anns) {
                     var a = am.annot;
                     switch(a.get_annot_type()) {
@@ -271,7 +275,9 @@ namespace pdfpc.Metadata {
                             break;
                     }
                 }
+#if !VALA_0_16
                 page.free_annot_mapping(anns);
+#endif
             }
         }
 


### PR DESCRIPTION
get_annot_mapping() is one of those things that changed from unowned to owned between vala 0.14 and 0.16.  This adds conditionals to do the right thing in both cases.

Of course, we're going to get rid of the 0.14 compatibility once the movie branch lands.  This will just make it more clear why things change then.
