### PR TITLE
Make argument of parse_command_line_options unowned

### DIFF
--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -84,7 +84,7 @@ namespace pdfpc {
          *
 		 * Returns the name of the pdf file to open (or null if not present)
          */
-        protected string? parse_command_line_options( string[] args ) {
+        protected string? parse_command_line_options( ref unowned string[] args ) {
             var context = new OptionContext( "<pdf-file>" );
 
             context.add_main_entries( options, null );
@@ -140,7 +140,7 @@ namespace pdfpc {
             Gdk.threads_init();
             Gtk.init( ref args );
 
-            string pdfFilename = this.parse_command_line_options( args );
+            string pdfFilename = this.parse_command_line_options( ref args );
 
             Gst.init( ref args );
 


### PR DESCRIPTION
After commit eb6d264a, I'm getting seg faults whenever running pdfpc with any options.  This fixes it for me, though I can't tell you why.
