### PR TITLE
Be more gentle when saving metadata

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -213,14 +213,10 @@ namespace pdfpc.Metadata {
                               + format_end_user_slide()
                               + format_notes();
             try {
-                if ( contents != "" ) {
+                var pdfpc_file = File.new_for_uri(this.pdfpc_url);
+                if (contents != "" || pdfpc_file.query_exists()) {
                     contents = "[file]\n" + this.pdf_fname + "\n" + contents;
-                    var pdfpc_file = File.new_for_uri(this.pdfpc_url);
-                    FileUtils.set_contents(pdfpc_file.get_path(), contents, contents.length-1);
-                } else { // We do not need to write anything. Delete the file if it exists
-                    var file = File.new_for_uri(this.pdfpc_url);
-                    if (file.query_exists())
-                        file.delete();
+                    pdfpc_file.replace_contents(contents.data, null, false, FileCreateFlags.NONE, null);
                 }
             } catch (Error e) {
                 error("%s", e.message);


### PR DESCRIPTION
Previously the .pdfpc file was deleted if pdfpc deemed it unnecessary and
was replaced completely with a new one if not. This has some disadvantages:
- no links can be used in place of .pdfpc files (neither symlinks nor hard links)
- file permissions get overwritten every time

This patch uses File.replace_contents() instead of FileUtils.set_contents() to
modify the metadata file. It does so if there is some actual useful metadata
to write or if threre was a metadata file before. This will work fine with links
but does no longer delete unnecessary metadata files after they were
created already. This should be no problem because usually metadata is
added not removed and the redundant file is harmless anyway.
