### PR TITLE
Initial support for latex beamer notes

### DIFF
--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -104,5 +104,10 @@ namespace pdfpc {
          * Position of notes on slides
          */
         public static string? notes_position = null;
+        
+        /**
+         * Position of beamer notes
+         */
+         public static string? beamer_notes_position = null;
     }
 }

--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -44,6 +44,11 @@ namespace pdfpc {
          * Cache store to be used
          */
         protected Renderer.Cache.Base cache = null;
+        
+        /**
+         * Beamer notes position
+         */
+         protected string? beamer_notes_position = null;
 
         /**
          * Base constructor taking a pdf metadata object as well as the desired
@@ -54,10 +59,11 @@ namespace pdfpc {
          * pdf document the renderspace is filled up completely cutting of a
          * part of the pdf document.
          */
-        public Pdf( Metadata.Pdf metadata, int width, int height, Metadata.Area area ) {
+        public Pdf( Metadata.Pdf metadata, int width, int height, Metadata.Area area, string? beamer_notes_position ) {
             base( metadata, width, height );
 
             this.area = area;
+            this.beamer_notes_position = beamer_notes_position;
 
             // Calculate the scaling factor needed.
             this.scaling_factor = Math.fmax( 
@@ -117,6 +123,13 @@ namespace pdfpc {
             cr.set_source_rgb( 255, 255, 255 );
             cr.rectangle( 0, 0, this.width, this.height );
             cr.fill();
+            
+            //Nothing to do for "right"
+            if(this.beamer_notes_position == "left")
+				cr.translate(-this.width,0);
+			//Nothing to do for "bottom"
+			if(this.beamer_notes_position == "top")
+				cr.translate(0, -this.height);
 
             cr.scale(this.scaling_factor, this.scaling_factor);
             cr.translate(-metadata.get_horizontal_offset(this.area), -metadata.get_vertical_offset(this.area));

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -59,18 +59,27 @@ namespace pdfpc {
         public static View.Pdf from_metadata( Metadata.Pdf metadata, int width, int height,
                                               Metadata.Area area,
                                               bool allow_black_on_end, bool clickable_links,
+                                              string? beamer_notes_position,
                                               PresentationController presentation_controller,
                                               out Rectangle scale_rect = null ) {
-            var scaler = new Scaler( 
-                metadata.get_page_width(),
-                metadata.get_page_height()
+            int scaler_width = 1;
+            int scaler_height = 1;
+            if(beamer_notes_position == "left" || beamer_notes_position == "right" )
+				scaler_width = 2;
+			if(beamer_notes_position == "top" || beamer_notes_position == "bottom" )
+				scaler_height = 2;
+					
+            var scaler = new Scaler(
+                metadata.get_page_width()/scaler_width,
+                metadata.get_page_height()/scaler_height
             );
             scale_rect = scaler.scale_to( width, height );
             var renderer = new Renderer.Pdf( 
                 metadata,
                 scale_rect.width,
                 scale_rect.height,
-                area
+                area,
+                beamer_notes_position
             );
             
             return new View.Pdf( renderer, allow_black_on_end, clickable_links, presentation_controller );

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -71,6 +71,7 @@ namespace pdfpc.Window {
                 Metadata.Area.CONTENT,
                 Options.black_on_end,
                 true,
+                Options.beamer_notes_position,
                 this.presentation_controller,
                 out scale_rect
             );

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -175,6 +175,7 @@ namespace pdfpc.Window {
                 Metadata.Area.NOTES,
                 Options.black_on_end,
                 true,
+                this.invert_beamer_notes_position(Options.beamer_notes_position),
                 this.presentation_controller,
                 out current_scale_rect
             );
@@ -193,6 +194,7 @@ namespace pdfpc.Window {
                 Metadata.Area.CONTENT,
                 true,
                 false,
+                Options.beamer_notes_position,
                 this.presentation_controller,
                 out next_scale_rect
             );
@@ -204,6 +206,7 @@ namespace pdfpc.Window {
                 Metadata.Area.CONTENT,
                 true,
                 false,
+                Options.beamer_notes_position,
                 this.presentation_controller,
                 out next_scale_rect
             );
@@ -214,6 +217,7 @@ namespace pdfpc.Window {
                 Metadata.Area.CONTENT,
                 true,
                 false,
+                Options.beamer_notes_position,
                 this.presentation_controller,
                 out next_scale_rect
             );
@@ -642,5 +646,18 @@ namespace pdfpc.Window {
         public View.Pdf? get_main_view() {
             return this.current_view as View.Pdf;
         }
+        
+        protected string? invert_beamer_notes_position(string? beamer_notes_position)
+        {
+			if(beamer_notes_position == "left")
+				return "right";
+			if(beamer_notes_position == "right")
+				return "left";
+			if(beamer_notes_position == "top")
+				return "bottom";
+			if(beamer_notes_position == "bottom")
+				return "top";
+			return null;
+		}
     }
 }

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -75,6 +75,7 @@ namespace pdfpc {
             { "list-actions", 'L', 0, 0, ref Options.list_actions, "List actions supported in the config file(s)", null},
             { "windowed", 'w', 0, 0, ref Options.windowed, "Run in windowed mode (devel tool)", null},
             { "notes", 'n', 0, OptionArg.STRING, ref Options.notes_position, "Position of notes on the pdf page (either left, right, top or bottom)", "P"},
+            { "beamer-notes", 'N', 0, OptionArg.STRING, ref Options.beamer_notes_position, "Position of beamer notes on the pdf page (either left, right, top or bottom)", "P"},
             { null }
         };
 


### PR DESCRIPTION
I once wrote a patch for the original Pdf-Presenter-Console to support latex beamer notes on the second screen: jakobwesthoff/Pdf-Presenter-Console#44.

I've adjusted that patch to work with the current version of pdfpc.

The solution is quite simple. Latex renders notes at the right or left side, below or above the actual content slide. The patch simply splits the pdf into two parts and renders the notes in the presenter and the content in the presentation window. The position of the notes on the pdf is defined by a new parameter 'beamer-notes' or 'N'.
