### PR TITLE
Added --other-screen=screen/monitor option.

### DIFF
--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -104,5 +104,50 @@ namespace pdfpc {
          * Position of notes on slides
          */
         public static string? notes_position = null;
+
+        /**
+         * Other screen to use
+         */
+        public static string? other_screen = null;
+    }
+
+    /**
+     * Screen number and monitor number passed in as
+     * [ScreenNum][/MonitorNum]
+     */
+    public struct ScreenMonitorNum {
+        /**
+         * Screen number, default to unspecified (-1)
+         */
+        public int screen_num;
+
+        /**
+         * Monitor number, default to unspecified (-1)
+         */
+        public int monitor_num;
+
+        /**
+         * Parse options into this structure
+         * [ScreenNum][/MonitorNum]
+         */
+        public ScreenMonitorNum(string? screen_monitor_str) {
+            this.screen_num  = -1;
+            this.monitor_num = -1;
+
+            if (screen_monitor_str == null) {
+                return;
+            }
+
+            if (screen_monitor_str.scanf("%d/%d", &this.screen_num, &this.monitor_num) <= 0) {
+                screen_monitor_str.scanf("/%d", &this.monitor_num);
+            }
+        }
+
+        /**
+         * Parse options into new structure
+         */
+        public static ScreenMonitorNum from_string(string? screen_monitor_str) {
+            return ScreenMonitorNum(screen_monitor_str);
+        }
     }
 }

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -53,21 +53,43 @@ namespace pdfpc.Window {
          */
         protected bool frozen = false;
 
-        public Fullscreen( int screen_num ) {
+        /**
+         * Screen and monitor number
+         */
+        protected int screen_num = -1;
+        protected int monitor_num = -1;
+
+        public Fullscreen( int screen_num, int monitor_num ) {
+            var display = Gdk.Display.get_default();
             Gdk.Screen screen;
 
-            if ( screen_num >= 0 ) {
-                // Start in the given monitor
-                screen = Screen.get_default();
-                screen.get_monitor_geometry( screen_num, out this.screen_geometry );
-            } else {
-                // Start in the monitor the cursor is in
-                var display = Gdk.Display.get_default();
-                int pointerx, pointery;
-                display.get_pointer(out screen, out pointerx, out pointery, null);
-                int current_screen = screen.get_monitor_at_point(pointerx, pointery);
-                screen.get_monitor_geometry( current_screen, out this.screen_geometry );
+            // Start in the given screen
+            if (screen_num >= 0) {
+                screen = display.get_screen(screen_num);
+                if ( monitor_num >= 0 ) {
+                    // Start in the given monitor
+                    screen.get_monitor_geometry( monitor_num, out this.screen_geometry );
+                } else {
+                    // Start in the primary monitor
+                    monitor_num = screen.get_primary_monitor();
+                    screen.get_monitor_geometry( monitor_num, out this.screen_geometry );
+                }
+            } else { // Start in default screen
+                if ( monitor_num >= 0 ) {
+                    // Start in the given monitor
+                    screen = Screen.get_default();
+                    screen.get_monitor_geometry( monitor_num, out this.screen_geometry );
+                } else {
+                    // Start in the monitor the cursor is in
+                    int pointerx, pointery;
+                    display.get_pointer(out screen, out pointerx, out pointery, null);
+                    monitor_num = screen.get_monitor_at_point(pointerx, pointery);
+                    screen.get_monitor_geometry( monitor_num, out this.screen_geometry );
+                }
             }
+            this.set_screen(screen);
+            this.screen_num = screen_num;
+            this.monitor_num = monitor_num;
 
             if ( !Options.windowed ) {
                 // Move to the correct monitor

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -44,8 +44,8 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presentation window
          */
-        public Presentation( Metadata.Pdf metadata, int screen_num, PresentationController presentation_controller ) {
-            base( screen_num );
+        public Presentation( Metadata.Pdf metadata, int screen_num, int monitor_num, PresentationController presentation_controller ) {
+            base( screen_num, monitor_num );
             this.role = "presentation";
 
             this.destroy.connect( (source) => {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -137,8 +137,8 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presenter window
          */
-        public Presenter( Metadata.Pdf metadata, int screen_num, PresentationController presentation_controller ) {
-            base( screen_num );
+        public Presenter( Metadata.Pdf metadata, int screen_num, int monitor_num, PresentationController presentation_controller ) {
+            base( screen_num, monitor_num );
             this.role = "presenter";
 
             this.destroy.connect( (source) => {


### PR DESCRIPTION
Support different screens (:0.0 and :0.1) with option
      --other-screen=1

I had an old fashioned dual screen setup with two "screens" (:0.0 and :0.1) which map to GdkScreen. This works well under xfce4 (used to work for GNOME2). I know this would eventually not be supported, but it has it's advantage for me (individual desktops on two screens). Anyway, here is my added option to use different GdkScreen for pdfpc.
