### PR TITLE
Adds support for sizing options for the windowed mode.

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -71,6 +71,12 @@ Force to use only one screen
 .BI "\-L, \-\-list\-actions"
 List actions supported in the config file(s)
 .TP
+.BI "\-w, \-\-windowed"
+Run in windowed mode
+.TP
+.BI "\-Z, \-\-size"
+Size of the presenter console in width:height format (forces windowed mode)
+.TP
 .BI "\-n, \-\-notes"=P
 Position of notes on the pdf page. Position can be either left, right, top or bottom (Default none)
 .TP
@@ -371,12 +377,12 @@ a frame of the movie will ensure the correct aspect ratio.
 There may be a small memory leak in the program. I am trying to solve it. It
 should not be too important for up to some hundreds of slides.
 
-Other bugs can be reported at 
+Other bugs can be reported at
 .I https://github.com/davvil/pdfpc/issues
 
 .SH CONTACT
 .PP
-Comments and suggestion are welcome. Write an email to 
+Comments and suggestion are welcome. Write an email to
 .I davvil@gmail.com
 
 .SH SEE ALSO

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -104,5 +104,10 @@ namespace pdfpc {
          * Position of notes on slides
          */
         public static string? notes_position = null;
+        
+        /**
+         * Size of the presenter window
+         */
+        public static string? size = null;
     }
 }

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -53,7 +53,7 @@ namespace pdfpc.Window {
          */
         protected bool frozen = false;
 
-        public Fullscreen( int screen_num ) {
+        public Fullscreen( int screen_num, int width = -1, int height = -1 ) {
             Gdk.Screen screen;
 
             if ( screen_num >= 0 ) {
@@ -84,11 +84,17 @@ namespace pdfpc.Window {
                 this.configure_event.connect( this.on_configure );
             }
             else {
-                this.screen_geometry.width /= 2;
-                this.screen_geometry.height /= 2;
+                if (width > 0 && height > 0) {
+                        this.screen_geometry.width = width;
+                        this.screen_geometry.height = height;
+                } else {
+                        this.screen_geometry.width /= 2;
+                        this.screen_geometry.height /= 2;
+                }
                 this.resizable = false;
+                
             }
-
+            
             this.add_events(EventMask.POINTER_MOTION_MASK);
             this.motion_notify_event.connect( this.on_mouse_move );
 

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -4,17 +4,17 @@
  * This file is part of pdfpc.
  *
  * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -92,9 +92,9 @@ namespace pdfpc.Window {
                         this.screen_geometry.height /= 2;
                 }
                 this.resizable = false;
-                
+
             }
-            
+
             this.add_events(EventMask.POINTER_MOTION_MASK);
             this.motion_notify_event.connect( this.on_mouse_move );
 
@@ -158,7 +158,7 @@ namespace pdfpc.Window {
             this.window.set_cursor( null );
 
             this.restart_hide_cursor_timer();
-            
+
             return false;
         }
 
@@ -186,7 +186,7 @@ namespace pdfpc.Window {
             // Window might be null in case it has not been mapped
             if ( this.window != null ) {
                 this.window.set_cursor(
-                    new Gdk.Cursor( 
+                    new Gdk.Cursor(
                         Gdk.CursorType.BLANK_CURSOR
                     )
                 );

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -44,8 +44,8 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presentation window
          */
-        public Presentation( Metadata.Pdf metadata, int screen_num, PresentationController presentation_controller ) {
-            base( screen_num );
+        public Presentation( Metadata.Pdf metadata, int screen_num, PresentationController presentation_controller, int width = -1, int height = -1 ) {
+            base( screen_num, width, height );
             this.role = "presentation";
 
             this.destroy.connect( (source) => {
@@ -64,10 +64,18 @@ namespace pdfpc.Window {
             
             Rectangle scale_rect;
             
+            if (width < 0) {
+                width = this.screen_geometry.width;
+            }
+            
+            if (height < 0) {
+                height = this.screen_geometry.height;
+            }
+            
             this.view = View.Pdf.from_metadata( 
                 metadata,
-                this.screen_geometry.width, 
-                this.screen_geometry.height,
+                width, 
+                height,
                 Metadata.Area.CONTENT,
                 Options.black_on_end,
                 true,

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -4,17 +4,17 @@
  * This file is part of pdfpc.
  *
  * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -89,7 +89,7 @@ namespace pdfpc {
             var context = new OptionContext( "<pdf-file>" );
 
             context.add_main_entries( options, null );
-            
+
             try {
                 context.parse( ref args );
             }
@@ -160,24 +160,24 @@ namespace pdfpc {
                 stderr.printf( "Error: No pdf file given\n");
                 Posix.exit(1);
             }
-            
+
             // parse size option
             // should be in the width:height format
 
             int width = -1, height = -1;
-            if ( Options.size != null ) 
+            if ( Options.size != null )
             {
                 int colonIndex = Options.size.index_of(":");
-                
+
                 width = int.parse(Options.size.substring(0, colonIndex));
                 height = int.parse(Options.size.substring(colonIndex + 1));
-                
+
                 if (width < 1 || height < 1) {
                     stderr.printf( "Error: Failed to parse size\n");
                     Posix.exit(1);
-                    
+
                 }
-                
+
                 Options.windowed = true;
             }
 
@@ -190,7 +190,7 @@ namespace pdfpc {
             var metadata = new Metadata.Pdf( pdfFilename, notes_position );
             if ( Options.duration != 987654321u )
                 metadata.set_duration(Options.duration);
-                
+
 
             // Initialize global controller and CacheStatus, to manage
             // crosscutting concerns between the different windows.
@@ -200,7 +200,7 @@ namespace pdfpc {
             ConfigFileReader configFileReader = new ConfigFileReader(this.controller);
             configFileReader.readConfig(etc_path + "/pdfpcrc");
             configFileReader.readConfig(Environment.get_home_dir() + "/.pdfpcrc");
-            
+
             var screen = Gdk.Screen.get_default();
             if ( !Options.windowed && !Options.single_screen && screen.get_n_monitors() > 1 ) {
                 int presenter_monitor, presentation_monitor;
@@ -209,9 +209,9 @@ namespace pdfpc {
                 else
                     presenter_monitor    = (screen.get_primary_monitor() + 1) % 2;
                 presentation_monitor = (presenter_monitor + 1) % 2;
-                this.presenter_window = 
+                this.presenter_window =
                     this.create_presenter_window( metadata, presenter_monitor );
-                this.presentation_window = 
+                this.presentation_window =
                     this.create_presentation_window( metadata, presentation_monitor, width, height );
             } else if (Options.windowed && !Options.single_screen) {
                 this.presenter_window =
@@ -233,7 +233,7 @@ namespace pdfpc {
                 this.presentation_window.show_all();
                 this.presentation_window.update();
             }
-            
+
             if ( this.presenter_window != null ) {
                 this.presenter_window.show_all();
                 this.presenter_window.update();


### PR DESCRIPTION
I wanted to use pdfpc in a kiosk mode for an interactive presentation where I would also have videos playing on the screen.  To do this, I needed to force a particular size for the windowed mode so I could have the presentation on one side and my videos on the other.  This pull request implements a size option (in pixels) for the width and height of the window (forces windowed mode).